### PR TITLE
Fixing issue of selecting a provider without using the arrow keys

### DIFF
--- a/input.go
+++ b/input.go
@@ -18,7 +18,11 @@ func PromptForConfigurationDetails(idpAccount *cfg.IDPAccount) error {
 
 	var err error
 
-	idpAccount.Provider, err = prompter.ChooseWithDefault("Please choose a provider:", idpAccount.Provider, providers)
+	defaultProvider := idpAccount.Provider
+	if defaultProvider == "" && len(providers) > 0 {
+		defaultProvider = providers[0]
+	}
+	idpAccount.Provider, err = prompter.ChooseWithDefault("Please choose a provider:", defaultProvider, providers)
 	if err != nil {
 		return errors.Wrap(err, "error selecting provider file")
 	}

--- a/pkg/prompter/survey.go
+++ b/pkg/prompter/survey.go
@@ -28,6 +28,10 @@ func (cli *CliPrompter) RequestSecurityCode(pattern string) string {
 
 // ChooseWithDefault given the choice return the option selected with a default
 func (cli *CliPrompter) ChooseWithDefault(pr string, defaultValue string, options []string) (string, error) {
+	if defaultValue == "" && len(options) > 0 {
+		defaultValue = options[0]
+	}
+
 	selected := ""
 	prompt := &survey.Select{
 		Message: pr,

--- a/pkg/provider/adfs/adfs.go
+++ b/pkg/provider/adfs/adfs.go
@@ -254,7 +254,7 @@ func updateOTPFormData(otpForm url.Values, s *goquery.Selection, token string) {
 	if strings.Contains(lname, "security_code") {
 		otpForm.Add(name, token)
 	} else if strings.Contains(lname, "totp") {
-		otpForm.Add(name, token)	
+		otpForm.Add(name, token)
 	} else if strings.Contains(lname, "verificationcode") {
 		otpForm.Add(name, token)
 	} else {


### PR DESCRIPTION
Using this project for the first time, the user experiences an issue causing the error "bad input" while selecting the identity provider.

This happens because at the first time there's no configuration file, so the value of field "Provider" in struct (*ConfigManager).*IDPAccount is set to an empty string (the zero value for this type). This field is passed as the default value for "prompter.ChooseWithDefault" inside function PromptForConfigurationDetails.

The solution proposed here is to check the value for the field "Provider", and if it's zeroed, we can use the first item available in slice "providers". Also, these changes are adding a similar check for *CliPrompter.ChooseWithDefault but in a more generic way, so if this happens with another field, the user won't experience this error again.